### PR TITLE
Add remote repo support to analyzer

### DIFF
--- a/main.go
+++ b/main.go
@@ -7,7 +7,7 @@ import (
 )
 
 func main() {
-	err := analyzer.AnalyzeSourceRoot([]string{
+	err := analyzer.AnalyzeRemoteRepos([]string{
 		//"/Users/amannmalik/GolandProjects/opentelemetry-collector",
 		//"/Users/amannmalik/GolandProjects/opentelemetry-collector-contrib",
 		//"/Users/amannmalik/GolandProjects/blackfriday",

--- a/pkg/analyzer/analyzer.go
+++ b/pkg/analyzer/analyzer.go
@@ -45,12 +45,19 @@ type Tag struct {
 	Options  []string `json:"options,omitempty"`
 }
 
-// AnalyzeSourceRoot analyzes a local git repository and extracts all types with struct tags usually associated with config files
-func AnalyzeSourceRoot(sourcePaths []string, destinationPath string) error {
+// AnalyzeRemoteRepos clones the provided remote repositories and analyzes their
+// contents. The analysis is written to destinationPath in JSON format.
+func AnalyzeRemoteRepos(remoteURIs []string, destinationPath string) error {
 	analyses := make([]*File, 0)
-	for _, sourcePath := range sourcePaths {
-		roots := locateModuleRoots(sourcePath)
-		result := doAnalyze(sourcePath, roots)
+	for _, uri := range remoteURIs {
+		roots, err := locateRemoteModuleRoots(uri)
+		if err != nil {
+			return err
+		}
+		result, err := doRemoteAnalyze(uri, roots)
+		if err != nil {
+			return err
+		}
 		analyses = append(analyses, result...)
 	}
 	content, err := json.MarshalIndent(analyses, "", "  ")
@@ -355,4 +362,47 @@ func alignPaths(base string, other string) string {
 		}
 	}
 	return other
+}
+
+func locateRemoteModuleRoots(remoteURI string) (map[string]string, error) {
+	results := map[string]string{}
+	err := WalkRemoteBlobs(remoteURI, func(path string, contents []byte) error {
+		if filepath.Base(path) == "go.mod" {
+			modulePath := modfile.ModulePath(contents)
+			results[filepath.Dir(path)] = modulePath
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
+func doRemoteAnalyze(remoteURI string, moduleRoots map[string]string) ([]*File, error) {
+	analyses := make([]*File, 0)
+	err := WalkRemoteBlobs(remoteURI, func(path string, contents []byte) error {
+		ext := filepath.Ext(path)
+		if ext == ".go" && !strings.HasSuffix(path, "_test.go") {
+			currentModulePath := resolveModule(path, moduleRoots)
+			if currentModulePath == "" {
+				return nil
+			}
+			fs := token.NewFileSet()
+			goSourceFile, err := parser.ParseFile(fs, path, contents, parser.ParseComments)
+			if err != nil {
+				return err
+			}
+			fmt.Printf("%s\n", path)
+			analysis := analyze(goSourceFile)
+			if analysis != nil {
+				relPath := alignPaths(currentModulePath, path)
+				analysis.Location = relPath
+				analysis.Module = currentModulePath
+				analyses = append(analyses, analysis)
+			}
+		}
+		return nil
+	})
+	return analyses, err
 }

--- a/pkg/analyzer/analyzer_test.go
+++ b/pkg/analyzer/analyzer_test.go
@@ -1,21 +1,16 @@
 package analyzer
 
 import (
+	"path/filepath"
 	"testing"
 )
 
 func TestBasic(t *testing.T) {
 	t.Run("basic", func(t *testing.T) {
-		err := AnalyzeSourceRoot([]string{
-			//"/Users/amannmalik/GolandProjects/opentelemetry-collector",
-			//"/Users/amannmalik/GolandProjects/opentelemetry-collector-contrib",
-			//"/Users/amannmalik/GolandProjects/blackfriday",
-			//"/Users/amannmalik/GolandProjects/runc",
-			//"/Users/amannmalik/GolandProjects/cgroups",
-			//"/Users/amannmalik/GolandProjects/sys",
-			//"/Users/amannmalik/GolandProjects/go-systemd",
-			"/Users/amannmalik/GolandProjects/runtime-spec/specs-go",
-		}, "analysis.json")
+		dest := filepath.Join(t.TempDir(), "analysis.json")
+		err := AnalyzeRemoteRepos([]string{
+			"https://github.com/opencontainers/runtime-spec",
+		}, dest)
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
## Summary
- add `AnalyzeRemoteRepos` for cloning remote repositories
- analyze files using `WalkRemoteBlobs`
- test against the runtime-spec repository
- update example in `main.go`

## Testing
- `go test ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684ae9d48a948324a929730a6d706a92